### PR TITLE
Move NOW section above hero on main page

### DIFF
--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -75,7 +75,6 @@ export const MainPage = () => {
           sticky
         />
         <MainPageMarquee />
-        <MainPageHero />
         <MainPageNowSection
           isAuth={isAuthResolved && isAuth}
           isDark={isDark}
@@ -90,6 +89,7 @@ export const MainPage = () => {
           onSubmit={handleAddNow}
           onDelete={handleDeleteNow}
         />
+        <MainPageHero />
         <MainPageWorkSection />
         <MainPagePortfolioSection />
         <MainPageContactSection />


### PR DESCRIPTION
### Motivation
- The NOW list was rendering at the bottom of the main page flow, so it needed to be moved higher in the layout so current NOW items appear before the hero section.

### Description
- Reordered the `MainPage` layout by moving `<MainPageNowSection>` to render immediately after `MainPageMarquee` and before `<MainPageHero>` in `frontend/src/pages/MainPage.tsx`.

### Testing
- Ran `npm run build` in `frontend/` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3784169883239d94b41d13dec435)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered main page content sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->