### PR TITLE
Add NOW cold-start loading state, route error boundary, and update router/vercel config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Notes
+
+- For frontend commands, prefer Bun (`bun run dev`, `bun run build`, `bun run lint`).
+- When adding async API-backed sections, include a user-visible loading state for cold starts.

--- a/frontend/src/components/main-page/MainPageMarquee.tsx
+++ b/frontend/src/components/main-page/MainPageMarquee.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+
 import { marqueeItems } from "@/data/text";
 
 const shuffleItems = (items: string[]) => {

--- a/frontend/src/components/main-page/MainPageNowSection.tsx
+++ b/frontend/src/components/main-page/MainPageNowSection.tsx
@@ -13,6 +13,7 @@ type MainPageNowSectionProps = {
   title: string;
   description: string;
   isSubmitting: boolean;
+  isLoading: boolean;
   onOpenChange: (open: boolean) => void;
   onTitleChange: (title: string) => void;
   onDescriptionChange: (description: string) => void;
@@ -30,6 +31,7 @@ export const MainPageNowSection = ({
   title,
   description,
   isSubmitting,
+  isLoading,
   onOpenChange,
   onTitleChange,
   onDescriptionChange,
@@ -75,6 +77,11 @@ export const MainPageNowSection = ({
             )}
           </div>
         </div>
+        {isLoading && (
+          <div className="mb-4 text-sm tracking-[0.15em]" style={{ color: "var(--bg)" }}>
+            FETCHING LATEST UPDATES… (COLD START CAN TAKE ~30S)
+          </div>
+        )}
         <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
           {visibleItems.map((item) => (
             <MainPageNowCard

--- a/frontend/src/components/shell/RouteErrorBoundary.tsx
+++ b/frontend/src/components/shell/RouteErrorBoundary.tsx
@@ -1,0 +1,19 @@
+import { isRouteErrorResponse, useRouteError } from "react-router";
+
+export const RouteErrorBoundary = () => {
+  const error = useRouteError();
+
+  const message = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : "Something went wrong while loading this page.";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--bg)] px-6 text-center text-[var(--ink)]">
+      <div>
+        <p className="text-sm tracking-[0.2em]">UNEXPECTED ERROR</p>
+        <h1 className="mt-2 text-2xl md:text-3xl">{message}</h1>
+        <p className="mt-3 text-sm opacity-80">Please refresh and try again.</p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -30,6 +30,7 @@ export const MainPage = () => {
   const [newDesc, setNewDesc] = useState("");
   const dialogMode = editingItem ? "edit" : "add";
   const isSubmitting = api.now.post.isPending || api.now.put.isPending;
+  const isNowLoading = api.now.get.isLoading || api.now.get.isPending;
 
   const resetNowForm = () => {
     setShowModal(false);
@@ -113,6 +114,7 @@ export const MainPage = () => {
           title={newTitle}
           description={newDesc}
           isSubmitting={isSubmitting}
+          isLoading={isNowLoading}
           onOpenChange={handleOpenChange}
           onTitleChange={setNewTitle}
           onDescriptionChange={setNewDesc}

--- a/frontend/src/utils/router.tsx
+++ b/frontend/src/utils/router.tsx
@@ -1,8 +1,11 @@
 import { createBrowserRouter } from "react-router";
 
+import { RouteErrorBoundary } from "@/components/shell/RouteErrorBoundary";
+
 export const router = createBrowserRouter([
   {
     path: "/",
+    errorElement: <RouteErrorBoundary />,
     lazy: async () => {
       const { MainPage } = await import("@/pages/MainPage");
 
@@ -11,6 +14,7 @@ export const router = createBrowserRouter([
   },
   {
     path: "/login",
+    errorElement: <RouteErrorBoundary />,
     lazy: async () => {
       const { MainLogin } = await import("@/pages/MainLogin");
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,3 +1,6 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
### Motivation

- Surface a user-visible loading state for the asynchronous NOW API to communicate cold-start delays. 
- Provide a route-level error UI to show friendly messages when a route fails to load. 
- Update client routing and Vercel configuration to improve SPA routing and error handling.

### Description

- Added `isLoading` prop to `MainPageNowSection` and render a prominent loading message when `isLoading` is true. 
- Introduced `isNowLoading` in `MainPage` to derive loading state from `api.now.get` and pass it into the NOW section. 
- Added a `RouteErrorBoundary` component and wired it into the router by renaming `router.ts` to `router.tsx` and adding `errorElement` entries for routes. 
- Replaced the `rewrites` Vercel configuration with `routes` that include a filesystem handle and an index fallback, and added `AGENTS.md` with frontend notes.

### Testing

- Ran a local build using the frontend toolchain (`bun run build`) and the build completed successfully. 
- Ran linting (`bun run lint`) and no lint errors were reported. 
- Verified TypeScript/typecheck for the frontend and there were no type errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8527162c8323b6ea742215a2cd04)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicator to the "Now" section while fetching data to improve user feedback during initial load.
  * Implemented error boundary for improved error page handling and user messaging.

* **Documentation**
  * Added guidelines document covering development best practices and requirements.

* **Chores**
  * Updated single-page app routing configuration for improved fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->